### PR TITLE
fix: add gateway URL to materialized location claims

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14974,7 +14974,7 @@
     },
     "packages/core": {
       "name": "@web3-storage/content-claims",
-      "version": "4.0.3",
+      "version": "4.0.5",
       "license": "Apache-2.0 OR MIT",
       "dependencies": {
         "@ucanto/client": "^9.0.1",


### PR DESCRIPTION
If `carpath` is already a URL, that is used. Otherwise, this adds `https://w3s.link/ipfs/<SHARD_CID>?format=raw&origin=r2://auto/carpark-prod-0` as a URL in the generated location claims.

Also removes the generated relation claim which doesn't provide any further information than the offset of the block header within the shard (which is minus a few bytes from the actual block offset). This is not used by freeway anymore when a location claim with real block offset and length is present (as we are generating here).