### PR TITLE
feat: use carpark bucket URL in materialized claims for legacy content

### DIFF
--- a/packages/lambda/src/lib/store/block-index.js
+++ b/packages/lambda/src/lib/store/block-index.js
@@ -67,7 +67,7 @@ export class BlockIndexClaimFetcher extends DynamoTable {
 
           // derive location URL(s) from the key
           location = [
-            ...(part ? [new URL(`https://carpark.w3s.link/${part}/${part}.car`)] : []),
+            ...(part ? [new URL(`https://carpark-prod-0.r2.w3s.link/${part}/${part}.car`)] : []),
             new URL(`https://${bucket}.s3.amazonaws.com/${key}`)
           ]
         }

--- a/packages/lambda/src/lib/store/block-index.js
+++ b/packages/lambda/src/lib/store/block-index.js
@@ -64,11 +64,10 @@ export class BlockIndexClaimFetcher extends DynamoTable {
           const [, bucket, ...rest] = carpath.split('/')
           const key = rest.join('/')
           const part = bucketKeyToPartCID(key)
-          const origin = encodeURIComponent('r2://auto/carpark-prod-0')
 
           // derive location URL(s) from the key
           location = [
-            ...(part ? [new URL(`https://w3s.link/ipfs/${part}?format=raw&origin=${origin}`)] : []),
+            ...(part ? [new URL(`https://carpark.w3s.link/${part}/${part}.car`)] : []),
             new URL(`https://${bucket}.s3.amazonaws.com/${key}`)
           ]
         }


### PR DESCRIPTION
Switches to using the `https://carpark-prod-0.r2.w3s.link/...` instead of a gateway link in content claims materialized for legacy content.